### PR TITLE
Adding Docker support to project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ruby:latest
+
+#
+# Setup NodeJS / Vim
+#
+RUN curl -sL https://deb.nodesource.com/setup | bash -
+RUN apt-get install -y nodejs vim
+
+#
+# Install Jekyll
+#
+RUN gem install bundler
+
+#
+# Run bundle install
+#
+ADD Gemfile /root/
+WORKDIR /root/
+RUN bundle install
+
+#
+# Project setup
+#
+RUN mkdir /root/jekyll
+WORKDIR /root/jekyll
+
+#
+# Listen to port 4000
+#
+EXPOSE 4000
+
+#
+# Entrypoints
+#
+ENTRYPOINT ["rake"]
+CMD ["preview"]

--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ At some point you want to link an external URL, in that case you could edit the 
 </nav>
 ```
 
+## Running Jekyll on Docker
+
+This project includes a **Dockerfile**, which allows lift a Jekyll container with this project and test it locally before pushing to Github.
+This container exposes port 4000 and expect a directory containing a valid Jekyll project on /root/jekyll.
+
+So, to lift the blog locally, follow the steps bellow:
+
+```bash
+# Build the image
+docker build -t zenvia/blog [Path do Dockerfile]
+
+# Lift the environment, mapping to port 4000 on localhost:
+docker run -p 4000:4000 -v $(pwd):/root/jekyll -d zenvia/blog
+```
+
+Now, the blog is accessible on [http://localhost:4000/](http://localhost:4000) :)
+
 ## License
 
 (The MIT License)


### PR DESCRIPTION
The project now provides a Dockerfile, which allows to lift the blog locally and test it before pushing to Github.
Instructions provided on README file
